### PR TITLE
Setting IP for gloo gateway

### DIFF
--- a/workloads/gloo/gloo-gateway.yaml
+++ b/workloads/gloo/gloo-gateway.yaml
@@ -138,6 +138,7 @@ spec:
   selector:
     gloo: gateway-proxy
   type: LoadBalancer
+  loadBalancerIP: 192.168.1.249
 
 ---
 # Source: gloo/templates/3-gloo-deployment.yaml


### PR DESCRIPTION
This will permit us to add static forwarding routes from router to cluster