### PR TITLE
stk ghost blog now a k8s svc

### DIFF
--- a/workloads/stk/ghost-pv.yaml
+++ b/workloads/stk/ghost-pv.yaml
@@ -8,12 +8,12 @@ spec:
   capacity:
     storage: 90Gi
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   iscsi:
     targetPortal: 192.168.1.4:3260
     portals: ['192.168.1.4:3260']
-    iqn: iqn.1991-05.com.microsoft:bmf-k8s-target
-    lun: 1
+    iqn: iqn.1991-05.com.microsoft:bmf-ghost-stk-target
+    lun: 0
     fsType: 'ext4'
     readOnly: false
 

--- a/workloads/stk/ghost-pvc.yaml
+++ b/workloads/stk/ghost-pvc.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ghost-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   volumeMode: Filesystem
   resources:
     requests:

--- a/workloads/stk/stk-svc.yaml
+++ b/workloads/stk/stk-svc.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: ghost-stk 
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ghost-stk 
+  template:
+    metadata:
+      labels:
+        app: ghost-stk
+    spec:
+      containers:
+      - name: ghost-stk
+        image: ghost:1.24
+        ports:
+        - name: http
+          containerPort: 2368
+        env:
+        - name: url
+          value: https://stufftoddknows.com
+        volumeMounts:
+        - mountPath: "/var/lib/ghost/content"
+          name: ghost-stk-vol
+      volumes:
+        - name: ghost-stk-vol
+          persistentVolumeClaim:
+            claimName: ghost-pvc
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ghost-stk
+spec:
+  ports:
+  - name: http
+    port: 3001
+    protocol: TCP
+    targetPort: 2368
+  selector:
+    app: ghost-stk
+  type: LoadBalancer
+  loadBalancerIP: 192.168.1.242


### PR DESCRIPTION
The STK blog (running on Ghost) had been hosted as a PoDC (plain 'ol docker container), but it's now

1. Running in a k8s pod
2. Persisting storage via a `PersistentStorageClaim` to `PersistentStorage` to iscsi
3. Exposed outside the bare metal cluster with [metlalb](https://github.com/google/metallb)

Although it's in a `replicaSet`, there is only one replica because not yet sure how the iscsi setup will handle multi-access rw.